### PR TITLE
KeyStore: Block key attestation for Google Play Services

### DIFF
--- a/keystore/java/android/security/KeyStore.java
+++ b/keystore/java/android/security/KeyStore.java
@@ -1127,6 +1127,10 @@ public class KeyStore {
         CertificateChainPromise promise = new CertificateChainPromise();
         try {
             mBinder.asBinder().linkToDeath(promise, 0);
+            // Prevent Google Play Services from using key attestation for SafetyNet
+            if (mContext.getPackageName().equals("com.google.android.gms")) {
+                return KeymasterDefs.KM_ERROR_UNIMPLEMENTED;
+            }
             if (params == null) {
                 params = new KeymasterArguments();
             }


### PR DESCRIPTION
In order to enforce SafetyNet security, Google Play Services is now
using hardware attestation for ctsProfile validation in all cases, even
when basic attestation is selected. The SafetyNet API response from GMS
will report that basic attestation was used, but under the hood,
hardware attestation is always used regardless of the reported state.
This results in SafetyNet failing to pass due to TrustZone reporting an
unlocked bootloader (and a partially invalidated root of trust) in the
key attestation result.

We can still take advantage of the fact that this usage of hardware
attestation is opportunistic - that is, it falls back to basic
attestation if key attestation fails to run - and prevent GMS from using
key attestation at the framework level. This causes it to gracefully
fall back to basic attestation and pass SafetyNet with an unlocked
bootloader.

Key attestation is still available for other apps, as there are valid
uses for it that do not involve SafetyNet.

The "not implemented" error code from keymaster is used to simulate the
most realistic failure condition to evade detection, i.e. an old device
that lacks support for key attestation.

Change-Id: I7282ab22b933434bb11037743d46b8a20dad063a
Signed-off-by: karthik558 <karthik.lal558@gmail.com>