### PR TITLE
SystemUI: Don't show FOD icon/pad keyguard if strong auth is required

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityContainer.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityContainer.java
@@ -525,9 +525,10 @@ public class KeyguardSecurityContainer extends FrameLayout implements KeyguardSe
 
         // Consume bottom insets because we're setting the padding locally (for IME and navbar.)
         int inset;
-        int minBottomMargin = mHasFod && mUpdateMonitor.isFingerprintDetectionRunning() ?
-                getResources().getDimensionPixelSize(
-                        R.dimen.kg_security_container_min_bottom_margin) : 0;
+        int minBottomMargin = mHasFod && !mUpdateMonitor.userNeedsStrongAuth() &&
+                mUpdateMonitor.isFingerprintDetectionRunning() ?
+                        getResources().getDimensionPixelSize(
+                                R.dimen.kg_security_container_min_bottom_margin) : 0;
 
         if (sNewInsetsMode == NEW_INSETS_MODE_FULL) {
             int bottomInset = insets.getInsetsIgnoringVisibility(systemBars()).bottom;

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -92,6 +92,11 @@ public class FODCircleView extends ImageView {
             new IFingerprintInscreenCallback.Stub() {
         @Override
         public void onFingerDown() {
+            if (mUpdateMonitor.userNeedsStrongAuth()) {
+                // Keyguard requires strong authentication (not biometrics)
+                return;
+            }
+
             mHandler.post(() -> showCircle());
         }
 
@@ -380,6 +385,11 @@ public class FODCircleView extends ImageView {
     }
 
     public void show() {
+        if (mUpdateMonitor.userNeedsStrongAuth()) {
+            // Keyguard requires strong authentication (not biometrics)
+            return;
+        }
+
         if (!mUpdateMonitor.isScreenOn()) {
             // Keyguard is shown just after screen turning off
             return;


### PR DESCRIPTION
This fixes a problem on some FOD devices where the FOD overlaps with the keyguard. This happens when you boot your phone and have to enter the pin code.

Original gerrit [commit](https://review.lineageos.org/c/LineageOS/android_frameworks_base/+/294910)

Sry for the bad image quality. I made the photos with my tablet.
Before:
![before](https://user-images.githubusercontent.com/24531178/118826542-dc56c000-b8bb-11eb-878a-a8b030796365.jpg)

After:
![after](https://user-images.githubusercontent.com/24531178/118826561-e1b40a80-b8bb-11eb-89ee-bc3a4f1e59bf.jpg)



